### PR TITLE
General project discovery's cleanup

### DIFF
--- a/bin/launch_multiple_nodes.sh
+++ b/bin/launch_multiple_nodes.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# This script launch several node so it easier to test federation and data repartition
+
+build/trinity-server --ca cert/ca.pem --cert cert/localhost.pem --loglevel info -memcache --memcacheport 11212 --node localhost:13531 --port 13532 &
+build/trinity-server --ca cert/ca.pem --cert cert/localhost.pem --loglevel info -memcache --memcacheport 11213 --node localhost:13531 --port 13533 &
+build/trinity-server --ca cert/ca.pem --cert cert/localhost.pem --loglevel info -memcache --memcacheport 11214 --node localhost:13531 --port 13534 &
+build/trinity-server --ca cert/ca.pem --cert cert/localhost.pem --loglevel info -memcache --memcacheport 11215 --node localhost:13531 --port 13535 &
+build/trinity-server --ca cert/ca.pem --cert cert/localhost.pem --loglevel info -memcache --memcacheport 11216 --node localhost:13531 --port 13536 &
+build/trinity-server --ca cert/ca.pem --cert cert/localhost.pem --loglevel info -memcache --memcacheport 11217 --node localhost:13531 --port 13537 &
+build/trinity-server --ca cert/ca.pem --cert cert/localhost.pem --loglevel info -memcache --memcacheport 11218 --node localhost:13531 --port 13538 &
+build/trinity-server --ca cert/ca.pem --cert cert/localhost.pem --loglevel info -memcache --memcacheport 11219 --node localhost:13531 --port 13539 &

--- a/bin/stress_test_connection.sh
+++ b/bin/stress_test_connection.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# This script just spawn and kill instance to see how the system react
+
+while [ 1 ]; do
+    timeout 1 build/trinity-server --ca cert/ca.pem --cert cert/localhost.pem --loglevel info --node localhost:13531 --port 13539
+done

--- a/config/config.go
+++ b/config/config.go
@@ -1,11 +1,11 @@
 package config
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 )
 
+// Config struct hold config information for the node
 type Config struct {
 	Nodes           NodeURLs
 	CA              *string
@@ -17,6 +17,7 @@ type Config struct {
 	HostAddr        *string
 }
 
+// NewConfig init a new Config struct with default value
 func NewConfig() *Config {
 	inst := &Config{}
 
@@ -38,10 +39,11 @@ func NewConfig() *Config {
 	return inst
 }
 
+// Validate configuration
 func (cfg *Config) Validate() (bool, []error) {
 	errs := []error{}
 	if *cfg.Port < 0 || *cfg.Port > 65535 {
-		errs = append(errs, errors.New(fmt.Sprintf("Port %d is invalid (0-65535)", *cfg.Port)))
+		errs = append(errs, fmt.Errorf("Port %d is invalid (0-65535)", *cfg.Port))
 	}
 	return len(errs) == 0, errs
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewConfig(t *testing.T) {

--- a/config/node_urls.go
+++ b/config/node_urls.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 )
 
+// NodeURLs Hold all the discovered nodes url as a list
 type NodeURLs []string
 
+// Set a new url to the list of nodes url
 func (nurl *NodeURLs) Set(value string) error {
 	*nurl = append(*nurl, value)
 	return nil

--- a/config/node_urls_test.go
+++ b/config/node_urls_test.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNodeURLs(t *testing.T) {

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -33,4 +33,4 @@ Work continues on [bplustree](https://github.com/tomdionysus/bplustree) which wi
 
 ## BUGS
 
-* In rare cicrumstances a node will be notified of its own address, and connect to itself.
+* In rare circumstances a node will be notified of its own address, and connect to itself.

--- a/kvstore/kvstore.go
+++ b/kvstore/kvstore.go
@@ -1,13 +1,14 @@
 package kvstore
 
 import (
+	"time"
+
 	bt "github.com/tomdionysus/binarytree"
 	ch "github.com/tomdionysus/consistenthash"
 	"github.com/tomdionysus/trinity/util"
-	"time"
 )
 
-// In Memory Key Value Store for testing.
+// KVStore In Memory Key Value Store for testing.
 type KVStore struct {
 	Logger  *util.Logger
 	store   *bt.Tree
@@ -15,12 +16,14 @@ type KVStore struct {
 	running bool
 }
 
+// Item struct represent an entry in the store
 type Item struct {
 	Key   string
 	Data  []byte
 	Flags int16
 }
 
+// NewKVStore create and initialize a new KVStore
 func NewKVStore(logger *util.Logger) *KVStore {
 	inst := &KVStore{
 		Logger:  logger,
@@ -31,12 +34,15 @@ func NewKVStore(logger *util.Logger) *KVStore {
 	return inst
 }
 
+// Init the KVStore
 func (kvs *KVStore) Init() {
 	kvs.Logger.Debug("KVStore", "Init")
 }
 
+// Start the KVStore goroutine
+// This goroutine looks for expiry of value and remove them from the KVStore
 func (kvs *KVStore) Start() {
-	if(kvs.running) {
+	if kvs.running {
 		return
 	}
 
@@ -58,10 +64,12 @@ func (kvs *KVStore) Start() {
 	}()
 }
 
+// Stop the value expiry
 func (kvs *KVStore) Stop() {
 	kvs.running = false
 }
 
+// Set a value in the KVStore
 func (kvs *KVStore) Set(key string, value []byte, flags int16, expiry *time.Time) {
 	keymd5 := ch.NewMD5Key(key)
 	item := &Item{Key: key, Data: value, Flags: flags}
@@ -76,11 +84,13 @@ func (kvs *KVStore) Set(key string, value []byte, flags int16, expiry *time.Time
 	}
 }
 
+// IsSet return if a key is set in the store
 func (kvs *KVStore) IsSet(key string) bool {
 	_, _, isset := kvs.Get(key)
 	return isset
 }
 
+// Get a value by key from the store
 func (kvs *KVStore) Get(key string) ([]byte, int16, bool) {
 	keymd5 := ch.NewMD5Key(key)
 	ok, valueInt := kvs.store.Get(keymd5)
@@ -94,6 +104,7 @@ func (kvs *KVStore) Get(key string) ([]byte, int16, bool) {
 	}
 }
 
+// Delete a value by key from the store
 func (kvs *KVStore) Delete(key string) bool {
 	kvs.Logger.Debug("KVStore", "DELETE [%s]", key)
 	return kvs.deleteKey(ch.NewMD5Key(key))

--- a/kvstore/kvstore_test.go
+++ b/kvstore/kvstore_test.go
@@ -1,10 +1,11 @@
 package kvstore
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/tomdionysus/trinity/util"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tomdionysus/trinity/util"
 )
 
 func TestNewKVStore(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/tomdionysus/trinity/kvstore"
 	"github.com/tomdionysus/trinity/network"
 	"github.com/tomdionysus/trinity/util"
+
 	// "github.com/tomdionysus/trinity/packets"
 	"os"
 )

--- a/network/ca_pool.go
+++ b/network/ca_pool.go
@@ -3,15 +3,18 @@ package network
 import (
 	"crypto/x509"
 	"errors"
-	"github.com/tomdionysus/trinity/util"
 	"io/ioutil"
+
+	"github.com/tomdionysus/trinity/util"
 )
 
+// CAPool struct represent a pool of x509 certificate
 type CAPool struct {
 	Pool   *x509.CertPool
 	Logger *util.Logger
 }
 
+// NewCAPool Create and initialise a CAPool
 func NewCAPool(logger *util.Logger) *CAPool {
 	inst := &CAPool{
 		Pool:   x509.NewCertPool(),
@@ -21,15 +24,16 @@ func NewCAPool(logger *util.Logger) *CAPool {
 	return inst
 }
 
-func (cp *CAPool) LoadPEM(certFile string) error {
-	cabytes, err := ioutil.ReadFile(certFile)
+// LoadPEM load a PEM file by name
+func (cp *CAPool) LoadPEM(certFileName string) error {
+	cabytes, err := ioutil.ReadFile(certFileName)
 	if err != nil {
-		cp.Logger.Error("CAPool", "Cannot Load CA File '%s': %s", certFile, err.Error())
+		cp.Logger.Error("CAPool", "Cannot Load CA File '%s': %s", certFileName, err.Error())
 		return err
 	}
 
 	if !cp.Pool.AppendCertsFromPEM(cabytes) {
-		cp.Logger.Error("CAPool", "Cannot Parse PEM CA File '%s'", certFile)
+		cp.Logger.Error("CAPool", "Cannot Parse PEM CA File '%s'", certFileName)
 		return errors.New("Cannot Parse CA File")
 	}
 

--- a/network/ca_pool_test.go
+++ b/network/ca_pool_test.go
@@ -1,9 +1,10 @@
 package network
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/tomdionysus/trinity/util"
-	"testing"
 )
 
 func TestNewCAPool(t *testing.T) {

--- a/network/ciphers.go
+++ b/network/ciphers.go
@@ -1,5 +1,6 @@
 package network
 
+// Ciphers exports the list of supported cypher suit
 var Ciphers map[uint16]string = map[uint16]string{
 	0x0005: "TLS_RSA_WITH_RC4_128_SHA",
 	0x000a: "TLS_RSA_WITH_3DES_EDE_CBC_SHA",

--- a/network/memcache.go
+++ b/network/memcache.go
@@ -3,11 +3,12 @@ package network
 import (
 	"bufio"
 	"fmt"
-	"github.com/tomdionysus/trinity/util"
 	"net"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/tomdionysus/trinity/util"
 )
 
 type MemcacheServer struct {
@@ -86,6 +87,10 @@ func (mcs *MemcacheServer) handleConnection(addr string, conn net.Conn) {
 		if err != nil {
 			if strings.HasSuffix(err.Error(), "use of closed network connection") {
 				mcs.Logger.Debug("Memcache", "[%s] -> Disconnected", addr)
+				break
+			}
+			if strings.HasSuffix(err.Error(), "EOF") {
+				mcs.Logger.Debug("Memcache", "[%s] -> Disconnected(malformed request)", addr)
 				break
 			}
 			mcs.Logger.Error("Memcache", "[%s] -> Error: %s", addr, err.Error())

--- a/network/memcache.go
+++ b/network/memcache.go
@@ -121,6 +121,9 @@ func (mcs *MemcacheServer) handleCommand(addr string, reader *bufio.Reader, writ
 	case "set":
 		mcs.handleSet(addr, reader, writer, args)
 		return false
+	case "add":
+		mcs.handleAdd(addr, reader, writer, args)
+		return false
 	case "get":
 		mcs.handleGet(addr, reader, writer, args)
 		return false
@@ -190,6 +193,68 @@ func (mcs *MemcacheServer) handleSet(addr string, reader *bufio.Reader, writer *
 	if expirytime != 0 {
 		expiry := time.Now().UTC().Add(time.Duration(expirytime) * time.Second)
 		expparam = &expiry
+	}
+	mcs.Server.SetKey(args[1], buf[:], int16(flags), expparam)
+	writer.WriteString("STORED\r\n")
+	writer.Flush()
+}
+
+func (mcs *MemcacheServer) handleAdd(addr string, reader *bufio.Reader, writer *bufio.Writer, args []string) {
+	if len(args) > 6 || len(args) < 5 {
+		writer.WriteString("ERROR\r\n")
+		writer.Flush()
+		return
+	}
+
+	mcs.Logger.Debug("Memcache", "[%s] -> Set %s", addr, args)
+
+	expirytime, err := strconv.Atoi(args[3])
+	if err != nil {
+		writer.WriteString("SERVER_ERROR\r\n")
+		writer.Flush()
+		return
+	}
+
+	flags, err := strconv.Atoi(args[2])
+	flags = flags & 0xFFFF
+	if err != nil {
+		writer.WriteString("SERVER_ERROR\r\n")
+		writer.Flush()
+		return
+	}
+
+	bytes, err := strconv.Atoi(args[4])
+	if err != nil {
+		writer.WriteString("SERVER_ERROR\r\n")
+		writer.Flush()
+		return
+	}
+
+	var buf []byte = make([]byte, bytes, bytes)
+	n, err := reader.Read(buf)
+	if err != nil || n != len(buf) {
+		writer.WriteString("SERVER_ERROR\r\n")
+		writer.Flush()
+		return
+	}
+
+	_, err = reader.ReadString('\n')
+	if err != nil {
+		writer.WriteString("SERVER_ERROR\r\n")
+		writer.Flush()
+		return
+	}
+
+	var expparam *time.Time = nil
+	if expirytime != 0 {
+		expiry := time.Now().UTC().Add(time.Duration(expirytime) * time.Second)
+		expparam = &expiry
+	}
+
+	if mcs.Server.IsSet(args[1]) == true {
+		writer.WriteString("NOT_STORED\r\n")
+		writer.Flush()
+		return
 	}
 	mcs.Server.SetKey(args[1], buf[:], int16(flags), expparam)
 	writer.WriteString("STORED\r\n")

--- a/network/peer.go
+++ b/network/peer.go
@@ -3,9 +3,11 @@ package network
 import (
 	"crypto/tls"
 	"errors"
+
 	"github.com/tomdionysus/consistenthash"
 	"github.com/tomdionysus/trinity/packets"
 	"github.com/tomdionysus/trinity/util"
+
 	// "bytes"
 	"encoding/gob"
 	"strings"
@@ -116,7 +118,7 @@ func (peer *Peer) Connect() error {
 
 // Disconnect disconnects the remote trinity instance and removes the peer from the TLSServer connections
 func (peer *Peer) Disconnect() {
-	if peer.State != PeerStateDisconnected {
+	if peer.ServerNetworkNode != nil && peer.State != PeerStateDisconnected {
 		peer.State = PeerStateDisconnected
 		peer.Server.ServerNode.DeregisterNode(peer.ServerNetworkNode)
 		if peer.HeartbeatTicker != nil {

--- a/network/peer.go
+++ b/network/peer.go
@@ -24,6 +24,7 @@ const (
 	PeerStateDefib        = iota
 )
 
+// PeerStateString exports helper for peer state
 var PeerStateString map[uint]string = map[uint]string{
 	PeerStateDisconnected: "PeerStateDisconnected",
 	PeerStateConnecting:   "PeerStateConnecting",
@@ -280,6 +281,7 @@ func (peer *Peer) SendDistribution() error {
 	return nil
 }
 
+// SendPacket send a packet without waiting for response from peer
 func (peer *Peer) SendPacket(packet *packets.Packet) error {
 	err := peer.Writer.Encode(packet)
 	if err != nil {
@@ -288,6 +290,7 @@ func (peer *Peer) SendPacket(packet *packets.Packet) error {
 	return err
 }
 
+// SendPacketWaitReply Send a packet to a peer and wait for reply
 func (peer *Peer) SendPacketWaitReply(packet *packets.Packet, timeout time.Duration) (*packets.Packet, error) {
 	if peer.State != PeerStateConnected {
 		peer.Logger.Error("Peer", "%02X: Cannot send packet ID %02X, not PeerStateConnected", peer.ServerNetworkNode.ID, packet.ID)

--- a/network/peer.go
+++ b/network/peer.go
@@ -21,6 +21,7 @@ const (
 	PeerStateHandshake    = iota
 	PeerStateConnected    = iota
 	PeerStateSyncing      = iota
+	PeerStateReady        = iota
 	PeerStateDefib        = iota
 )
 
@@ -31,6 +32,7 @@ var PeerStateString map[uint]string = map[uint]string{
 	PeerStateHandshake:    "PeerStateHandshake",
 	PeerStateConnected:    "PeerStateConnected",
 	PeerStateSyncing:      "PeerStateSyncing",
+	PeerStateReady:        "PeerStateReady",
 	PeerStateDefib:        "PeerStateDefib",
 }
 
@@ -50,7 +52,7 @@ type Peer struct {
 	// State is the State of the peer
 	State uint
 
-	// Connecton is the underlying TLS secured connection
+	// Connection is the underlying TLS secured connection
 	Connection *tls.Conn
 
 	// HeartbeatTicker is the ticker used to generate heartbeat packets (every 1s)
@@ -275,6 +277,7 @@ func (peer *Peer) handleReply(packet *packets.Packet) {
 	}
 }
 
+// SendDistribution send node information about to the peer
 func (peer *Peer) SendDistribution() error {
 	packet := packets.NewPacket(packets.CMD_DISTRIBUTION, peer.Server.ServerNode.ServerNetworkNode)
 	peer.SendPacket(packet)

--- a/network/peer_CMD_DISTRIBUTION.go
+++ b/network/peer_CMD_DISTRIBUTION.go
@@ -1,9 +1,10 @@
 package network
 
 import (
+	"time"
+
 	"github.com/tomdionysus/consistenthash"
 	"github.com/tomdionysus/trinity/packets"
-	"time"
 )
 
 // process_CMD_DISTRIBUTION processes a CMD_DISTRIBUTION packet received from a peer.

--- a/network/tls_server.go
+++ b/network/tls_server.go
@@ -169,9 +169,9 @@ func (svr *TLSServer) NotifyAllPeers() {
 
 	for id, peer := range currentConns {
 		payload := packets.PeerListPacket{}
-		for listId, listPeer := range currentConns {
-			if listId != id {
-				payload[listId] = listPeer.ServerNetworkNode.HostAddr
+		for listID, listPeer := range currentConns {
+			if listID != id {
+				payload[listID] = listPeer.ServerNetworkNode.HostAddr
 			}
 		}
 		peer.SendPacket(packets.NewPacket(packets.CMD_PEERLIST, payload))

--- a/network/tls_server.go
+++ b/network/tls_server.go
@@ -7,13 +7,14 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"net"
+	"sync"
+	"time"
+
 	ch "github.com/tomdionysus/consistenthash"
 	"github.com/tomdionysus/trinity/kvstore"
 	"github.com/tomdionysus/trinity/packets"
 	"github.com/tomdionysus/trinity/util"
-	"net"
-	"sync"
-	"time"
 )
 
 // Commands
@@ -258,6 +259,54 @@ func (svr *TLSServer) GetKey(key string) ([]byte, int16, bool) {
 		}
 	}
 	return []byte{}, 0, false
+}
+
+// IsSet return if a key is set
+func (svr *TLSServer) IsSet(key string) bool {
+	keymd5 := ch.NewMD5Key(key)
+	nodes := svr.ServerNode.GetNodesFor(keymd5, 3)
+	for _, node := range nodes {
+		if node.ID == svr.ServerNode.ID {
+			svr.Logger.Debug("Server", "GetKey: Peer for key %02X -> %02X (Local)", keymd5, node.ID)
+			// Local set.
+			return svr.KVStore.IsSet(key)
+		} else {
+			svr.Logger.Debug("Server", "GetKey: Peer for key %02X -> %02X (Remote)", keymd5, node.ID)
+
+			peer, _ := svr.ConnectionGet(node.ID)
+			if peer.State != PeerStateConnected {
+				svr.Logger.Warn("Server", "GetKey: Peer for key %02X -> %02X (Remote) Unavailable", keymd5, node.ID)
+				continue
+			}
+
+			// Remote Set.
+			payload := packets.KVStorePacket{
+				Command:  packets.CMD_KVSTORE_IS_SET,
+				Key:      key,
+				KeyHash:  keymd5,
+				TargetID: node.ID,
+			}
+			packet := packets.NewPacket(packets.CMD_KVSTORE, payload)
+			reply, err := peer.SendPacketWaitReply(packet, 5*time.Second)
+
+			// Process reply or timeout
+			if err == nil {
+				switch reply.Command {
+				case packets.CMD_KVSTORE_ACK:
+					svr.Logger.Debug("Server", "GetKey: Reply from Remote %s", key)
+					return true
+				case packets.CMD_KVSTORE_NOT_FOUND:
+					svr.Logger.Debug("Server", "GetKey: Reply from Remote %s Not Found", key)
+					return false
+				default:
+					svr.Logger.Warn("Server", "GetKey: Unknown Reply Command %d", reply.Command)
+				}
+			} else {
+				svr.Logger.Warn("Server", "GetKey: Reply Timeout")
+			}
+		}
+	}
+	return false
 }
 
 // DeleteKey clears the given key in the cluster.

--- a/network/tls_server_test.go
+++ b/network/tls_server_test.go
@@ -1,8 +1,9 @@
 package network
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTLSServer(t *testing.T) {

--- a/packets/kvstore_packet.go
+++ b/packets/kvstore_packet.go
@@ -3,6 +3,7 @@ package packets
 import (
 	"encoding/gob"
 	"time"
+
 	ch "github.com/tomdionysus/consistenthash"
 )
 
@@ -14,6 +15,7 @@ const (
 	CMD_KVSTORE_SET    = 1
 	CMD_KVSTORE_GET    = 2
 	CMD_KVSTORE_DELETE = 3
+	CMD_KVSTORE_IS_SET = 4
 )
 
 type KVStorePacket struct {
@@ -25,7 +27,7 @@ type KVStorePacket struct {
 	ExpiresAt *time.Time
 	Flags     int16
 
-	TargetID  ch.NodeId
+	TargetID ch.NodeId
 }
 
 func init() {

--- a/packets/kvstore_packet_test.go
+++ b/packets/kvstore_packet_test.go
@@ -1,8 +1,9 @@
 package packets
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestKVStorePacket(t *testing.T) {

--- a/packets/packet.go
+++ b/packets/packet.go
@@ -1,21 +1,26 @@
 package packets
 
 import (
-	ch "github.com/tomdionysus/consistenthash"
 	"time"
+
+	ch "github.com/tomdionysus/consistenthash"
 )
 
 const (
 	CMD_HEARTBEAT    = 1
 	CMD_DISTRIBUTION = 2
+	CMD_STATUS_SYNC  = 3
 )
 
+// PacketId is an alias for storing a consistenthash key
 type PacketId ch.Key
 
+// NewRandomPacketId Generate a new id for sending packet
 func NewRandomPacketId() PacketId {
 	return PacketId(ch.NewRandomKey())
 }
 
+// Packet represent a system packet
 type Packet struct {
 	Command   uint16
 	ID        PacketId
@@ -25,6 +30,7 @@ type Packet struct {
 	Payload interface{}
 }
 
+// NewPacket Generate a packet which are not going to wait for a response
 func NewPacket(command uint16, payload interface{}) *Packet {
 	inst := &Packet{
 		Command: command,
@@ -35,11 +41,12 @@ func NewPacket(command uint16, payload interface{}) *Packet {
 	return inst
 }
 
-func NewResponsePacket(command uint16, requestid PacketId, payload interface{}) *Packet {
+// NewResponsePacket Generate a packet which are going to wait for a response
+func NewResponsePacket(command uint16, requestID PacketId, payload interface{}) *Packet {
 	inst := &Packet{
 		Command:   command,
 		ID:        NewRandomPacketId(),
-		RequestID: requestid,
+		RequestID: requestID,
 		Sent:      time.Now(),
 		Payload:   payload,
 	}

--- a/packets/packet_test.go
+++ b/packets/packet_test.go
@@ -1,9 +1,10 @@
 package packets
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/tomdionysus/consistenthash"
-	"testing"
 )
 
 func TestNewPacket(t *testing.T) {

--- a/packets/peerlist_packet.go
+++ b/packets/peerlist_packet.go
@@ -2,6 +2,7 @@ package packets
 
 import (
 	"encoding/gob"
+
 	"github.com/tomdionysus/consistenthash"
 )
 

--- a/util/memcached_set_helper.go
+++ b/util/memcached_set_helper.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"strconv"
+)
+
+// MemcachedSetArgsHelper helps handleing argument for the set, add and replace memcached commands
+func MemcachedSetArgsHelper(args []string) (int, int, int, error) {
+	expirytime, err := strconv.Atoi(args[3])
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	flags, err := strconv.Atoi(args[2])
+	flags = flags & 0xFFFF
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	bytes, err := strconv.Atoi(args[4])
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	return expirytime, flags, bytes, nil
+}

--- a/util/memcached_set_helper_test.go
+++ b/util/memcached_set_helper_test.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemcachedSetArgsHelperCommonUse(t *testing.T) {
+	args := make([]string, 6)
+	args[0] = "set"
+	args[1] = "test"
+	args[2] = "0"
+	args[3] = "100"
+	args[4] = "0"
+
+	expire, flags, bytes, err := MemcachedSetArgsHelper(args)
+	assert.Nil(t, err)
+	assert.Equal(t, expire, 100)
+	assert.Equal(t, flags, 0)
+	assert.Equal(t, bytes, 0)
+}
+
+func TestMemcachedSetArgsHelperIntToBig(t *testing.T) {
+	args := make([]string, 6)
+	args[0] = "set"
+	args[1] = "test"
+	args[2] = "0"
+	args[3] = "10000000000000000000000000000"
+	args[4] = "0"
+
+	expire, flags, bytes, err := MemcachedSetArgsHelper(args)
+	assert.NotNil(t, err)
+	assert.Equal(t, expire, 0)
+	assert.Equal(t, flags, 0)
+	assert.Equal(t, bytes, 0)
+}
+
+func TestMemcachedSetArgsHelperErrorNotNumber(t *testing.T) {
+	args := make([]string, 6)
+	args[0] = "set"
+	args[1] = "test"
+	args[2] = "AAAAAAAAAAAAAAAAA"
+	args[3] = "100"
+	args[4] = "0"
+
+	expire, flags, bytes, err := MemcachedSetArgsHelper(args)
+	assert.NotNil(t, err)
+	assert.Equal(t, expire, 0)
+	assert.Equal(t, flags, 0)
+	assert.Equal(t, bytes, 0)
+}


### PR DESCRIPTION
This is a general purpose PR about fixing various little superfluous details on the project.

First two commit are solving a crash and a deadlock. To reproduce them launch a trinity instance with memcache interface, then use postman to send a GET request to the server port (one on the trinity control port crash the server, one on the memcache interface create a deadlock)

I have after that added some support of the memcached protocol with the `add` and `replace` command. I have implemented an internal `is_set` query that ask instances if the key is set on the node without sending the value.

All other commit are adding some documentation, fixing typo, and refactoring some part of the code plus some script I think may be useful.

Regarding the refactoring, I have put the memcache_set_helper function in the util directory, but it could be placed into the network/memcached one.